### PR TITLE
fix image names, build badges to refer to the real image and repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Contributed by [Elastic](https://github.com/elastic) from their [initial impleme
 
 #### Build status
 
-![go build](https://github.com/crossplane-contrib/crossplane-function-cue/actions/workflows/go-build.yaml/badge.svg?branch=main)
-[![Go Report Card](https://goreportcard.com/badge/github.com/crossplane-contrib/crossplane-function-cue)](https://goreportcard.com/report/github.com/elastic/crossplane-function-cue)
-[![Go Coverage](https://github.com/crossplane-contrib/crossplane-function-cue/wiki/coverage.svg)](https://raw.githack.com/wiki/elastic/crossplane-function-cue/coverage.html)
+![go build](https://github.com/crossplane-contrib/function-cue/actions/workflows/go-build.yaml/badge.svg?branch=main)
+[![Go Report Card](https://goreportcard.com/badge/github.com/crossplane-contrib/function-cue)](https://goreportcard.com/report/github.com/crossplane-contrib/function-cue)
+[![Go Coverage](https://github.com/crossplane-contrib/function-cue/wiki/coverage.svg)](https://raw.githack.com/wiki/elastic/function-cue/coverage.html)
 
 ## Building
 

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -20,8 +20,8 @@ SHELL=bash
 CUE_VERSION?=v0.7.0
 DYFF_VERSION?=v1.7.0
 
-FN_CUE_VERSION?=test
-FN_IMAGE:=docker.io/gotwarlost/function-cue
+FN_CUE_VERSION?=v0.2.0
+FN_IMAGE:=xpkg.upbound.io/crossplane-contrib/function-cue
 
 MAKE=make --no-print-directory
 

--- a/examples/simple/helm/zz_generated/functions.yaml
+++ b/examples/simple/helm/zz_generated/functions.yaml
@@ -1,7 +1,7 @@
 metadata:
   name: fn-cue-examples-simple
 spec:
-  package: docker.io/gotwarlost/function-cue:test
+  package: xpkg.upbound.io/crossplane-contrib/function-cue:v0.2.0
   packagePullPolicy: Always
 kind: Function
 apiVersion: pkg.crossplane.io/v1beta1

--- a/examples/simple/pkg/functions.cue
+++ b/examples/simple/pkg/functions.cue
@@ -11,7 +11,7 @@ _functions: cuefn: xp.#Function & {
 		name: "fn-cue-examples-simple"
 	}
 	spec: {
-		package:           string | *"docker.io/gotwarlost/function-cue:test" @tag(image)
+		package:           string | *"xpkg.upbound.io/crossplane-contrib/function-cue:@v0.2.0" @tag(image)
 		packagePullPolicy: "Always"
 	}
 }


### PR DESCRIPTION
Also verified that the example can be built and deployed correctly, and functions as expected for the `replicatedmap` type.

This verification needs to become part of an acceptance test during the build.