### PR TITLE
Fix bugs in the cue unit tester after the refactor

### DIFF
--- a/internal/cuetools/testdata/runtime/impl.cue
+++ b/internal/cuetools/testdata/runtime/impl.cue
@@ -1,7 +1,7 @@
 package runtime
 
 response: desired:resources: main: resource: {
-	foo: request.observed.composite.resource.foo
+	foo: #request.observed.composite.resource.foo
 	bar: "baz"
 }
 

--- a/internal/cuetools/testdata/runtime/tests/correct.cue
+++ b/internal/cuetools/testdata/runtime/tests/correct.cue
@@ -1,7 +1,7 @@
 @if(correct)
 package tests
 
-request: observed: composite: resource: {
+#request: observed: composite: resource: {
 	foo: "bar"
 }
 

--- a/internal/cuetools/testdata/runtime/tests/incorrect.cue
+++ b/internal/cuetools/testdata/runtime/tests/incorrect.cue
@@ -1,7 +1,7 @@
 @if(incorrect)
 package tests
 
-request: observed: composite: resource: {
+#request: observed: composite: resource: {
 	foo: "foo2"
 }
 

--- a/internal/cuetools/testdata/runtime2/impl.cue
+++ b/internal/cuetools/testdata/runtime2/impl.cue
@@ -1,0 +1,7 @@
+package runtime
+
+resources: main: resource: {
+	foo: _request.observed.composite.resource.foo
+	bar: "baz"
+}
+

--- a/internal/cuetools/testdata/runtime2/init.cue
+++ b/internal/cuetools/testdata/runtime2/init.cue
@@ -4,4 +4,4 @@ import(
 	"github.com/crossplane-contrib/function-cue/testdata/runtime/util"
 )
 
-#request: util.#RequestSchema
+_request: util.#RequestSchema

--- a/internal/cuetools/testdata/runtime2/tests/correct.cue
+++ b/internal/cuetools/testdata/runtime2/tests/correct.cue
@@ -1,0 +1,11 @@
+@if(correct)
+package tests
+
+_request: observed: composite: resource: {
+	foo: "bar"
+}
+
+resources: main: resource: {
+		foo: "bar"
+		bar: "baz"
+}

--- a/internal/cuetools/testdata/runtime2/tests/incorrect.cue
+++ b/internal/cuetools/testdata/runtime2/tests/incorrect.cue
@@ -1,0 +1,11 @@
+@if(incorrect)
+package tests
+
+_request: observed: composite: resource: {
+	foo: "foo2"
+}
+
+resources: main: resource: {
+		foo: "bar"
+		bar: "baz"
+}

--- a/internal/cuetools/testdata/runtime2/util/util.cue
+++ b/internal/cuetools/testdata/runtime2/util/util.cue
@@ -1,0 +1,3 @@
+package util
+
+#RequestSchema: {...}


### PR DESCRIPTION
* The default request variable was being set to "request" and not "#request" which was a late change in the prior commit
* Legacy options were not being correctly honored
* Add a new test for ensuring that lagcy options are honored correctly