### PR TITLE
fix debug response when a response var is present

### DIFF
--- a/internal/fn/fn.go
+++ b/internal/fn/fn.go
@@ -131,7 +131,11 @@ func (f *Cue) Eval(in *fnv1beta1.RunFunctionRequest, script string, opts EvalOpt
 		return nil, errors.Wrap(err, "marshal cue output")
 	}
 	if opts.Debug.Enabled {
-		log.Printf("[response:begin]\n%s\n[response:end]\n", f.getDebugString(resBytes, opts.Debug.Raw))
+		preamble = ""
+		if opts.ResponseVar != "" {
+			preamble = opts.ResponseVar + ":"
+		}
+		log.Printf("[response:begin]\n%s %s\n[response:end]\n", preamble, f.getDebugString(resBytes, opts.Debug.Raw))
 	}
 
 	var ret fnv1beta1.RunFunctionResponse


### PR DESCRIPTION
Previously, the entire response returned by cue was also the crossplane response so it made sense to dump it as-is such that users could copy the request and response objects unmodified into their unit tests.

Now that we support extracting a variable from the response, we need to replay it back with that variable such that copying the debug response output unmodified yields a correct test. That is, we do the same processing for responses as we do for requests.