### PR TITLE
fix example in README, fixes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,11 @@ and reference it in a composition as follows:
       input:
         apiVersion: fn-cue/v1    # can be anything
         kind: CueFunctionParams  # can be anything
-        spec:
-          source: Inline         # only Inline is supported for now
-          script: |              # text of cue program
-            text of cue program
-          # show inputs and outputs for the composition in the pod log in pretty format
-          debug: true  
+        source: Inline         # only Inline is supported for now
+        script: |              # text of cue program
+          text of cue program
+        # show inputs and outputs for the composition in the pod log in pretty format
+        debug: true  
 ```
 
 The full spec of the input object can be [found here](input/v1beta1/input.go)


### PR DESCRIPTION
When migrating from crossplane-function-cue to function-cue, I cleaned up the input to match other functions to not have a `spec` attribute. This update was missed in the README.