### PR TITLE
add OWNERS.md to meet standards

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2023 The Crossplane Authors <https://crossplane.io>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# OWNERS
+
+This page lists all maintainers for **this** repository. Each repository in the
+[Crossplane organization](https://github.com/crossplane/) will list their
+repository maintainers in their own `OWNERS.md` file.
+
+## Maintainers
+
+* Krishnan Anantheswaran ([gotwarlost](https://github.com/gotwarlost))
+* Bryan Nobuhara ([Mitsuwa](https://github.com/Mitsuwa))
+
+See [CODEOWNERS](./CODEOWNERS) for automatic PR assignment.


### PR DESCRIPTION
# What

This is one of many updates that are needed to meet the Extension compliance requests from https://github.com/crossplane-contrib/function-cue/issues/19.  This creates the OWNERS.md file.

@gotwarlost please take a look