### PR TITLE
fix(build cache): Bump dockerbuildx to 0.22.0

### DIFF
--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Download Single-Platform Packages
         uses: actions/download-artifact@v4
         with:
-          path: "."
+          path: .
           merge-multiple: true
           pattern: "!*.dockerbuild" # This gets uploaded by docker/build-push-action but must be skipped: https://github.com/actions/toolkit/pull/1874
 

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   GO_VERSION: '1.23.1'
-  DOCKER_BUILDX_VERSION: 'v0.21.0'
+  DOCKER_BUILDX_VERSION: 'v0.22.0'
   XP_CHANNEL: master
   XP_VERSION: current
   XPKG_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Download Single-Platform Packages
         uses: actions/download-artifact@v4
         with:
-          path: .
+          path: "*.xpkg"
           merge-multiple: true
 
       - name: Setup the Crossplane CLI

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -91,8 +91,9 @@ jobs:
       - name: Download Single-Platform Packages
         uses: actions/download-artifact@v4
         with:
-          path: "*.xpkg"
+          path: "."
           merge-multiple: true
+          pattern: "!*.dockerbuild" # This gets uploaded by docker/build-push-action but must be skipped: https://github.com/actions/toolkit/pull/1874
 
       - name: Setup the Crossplane CLI
         run: "curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"

--- a/.github/workflows/docker-build-push.yaml
+++ b/.github/workflows/docker-build-push.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   GO_VERSION: '1.23.1'
-  DOCKER_BUILDX_VERSION: 'v0.11.2'
+  DOCKER_BUILDX_VERSION: 'v0.21.0'
   XP_CHANNEL: master
   XP_VERSION: current
   XPKG_ACCESS_ID: ${{ secrets.XPKG_ACCESS_ID }}


### PR DESCRIPTION
# What

We are also running into this issue

```
ERROR: failed to solve: This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset
```
https://docs.docker.com/build/ci/github-actions/cache/#github-cache

Try 0.22.0 as this should fix this issue - see: https://github.com/docker/build-push-action/issues/1345


