### PR TITLE
Add unification assertion mode

### DIFF
--- a/internal/cuetools/testdata/assertionmodes/tests/incorrect_unification.cue
+++ b/internal/cuetools/testdata/assertionmodes/tests/incorrect_unification.cue
@@ -1,0 +1,13 @@
+
+@if(incorrect_unification)
+package tests
+
+#request: observed: composite: resource: {
+	foo: "bar"
+}
+
+response: {
+    desired: resources: main: resource: {
+		foo: "baz"
+	}
+} @assertionMode(unification)

--- a/internal/cuetools/testdata/assertionmodes/tests/incorrect_unification_extra.cue
+++ b/internal/cuetools/testdata/assertionmodes/tests/incorrect_unification_extra.cue
@@ -1,0 +1,15 @@
+
+@if(incorrect_unification_extra)
+package tests
+
+#request: observed: composite: resource: {
+	foo: "bar"
+}
+
+#mode: "unification"
+
+response: {
+    desired: resources: main: resource: {
+		extra: "value"
+	}
+} @assertionMode(unification)

--- a/internal/cuetools/testdata/assertionmodes/tests/unification.cue
+++ b/internal/cuetools/testdata/assertionmodes/tests/unification.cue
@@ -1,0 +1,12 @@
+@if(unification)
+package tests
+
+#request: observed: composite: resource: {
+	foo: "bar"
+}
+
+response: {
+    desired: resources: main: resource: {
+		foo: "bar"
+	}
+} @assertionMode(unification)


### PR DESCRIPTION
Adds a way of asserting via unification instead of diffing in tests.

Diffing always requires including the full desired output in the test, which for some use-cases may obfuscate the point the test is trying to show.

Unification allows to assert on just a sub-set of the complete object and leverages Cue itself to validate that the actual matches the expected output. This may of course lead to a scenario that not all of the output has been validated in each individual test, but makes it easier to see the effects the test-case is stressing.