### PR TITLE
pkg: switch Function package APIs from v1beta1 to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ make docker # build docker image
 
 You define the function as follows:
 ```yaml
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: fn-cue

--- a/examples/simple/helm/zz_generated/functions.yaml
+++ b/examples/simple/helm/zz_generated/functions.yaml
@@ -4,13 +4,13 @@ spec:
   package: xpkg.upbound.io/crossplane-contrib/function-cue:v0.2.0
   packagePullPolicy: Always
 kind: Function
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 ---
 metadata:
   name: fn-auto-ready
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.2.1
 kind: Function
-apiVersion: pkg.crossplane.io/v1beta1
+apiVersion: pkg.crossplane.io/v1
 
 ---

--- a/examples/simple/pkg/functions.cue
+++ b/examples/simple/pkg/functions.cue
@@ -5,7 +5,7 @@ import (
 )
 
 _functions: cuefn: xp.#Function & {
-	apiVersion: "pkg.crossplane.io/v1beta1"
+	apiVersion: "pkg.crossplane.io/v1"
 	kind:       "Function"
 	metadata: {
 		name: "fn-cue-examples-simple"
@@ -17,7 +17,7 @@ _functions: cuefn: xp.#Function & {
 }
 
 _functions: readyFn: xp.#Function & {
-	apiVersion: "pkg.crossplane.io/v1beta1"
+	apiVersion: "pkg.crossplane.io/v1"
 	kind:       "Function"
 	metadata: name: "fn-auto-ready"
 	spec: {

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: meta.pkg.crossplane.io/v1beta1
+apiVersion: meta.pkg.crossplane.io/v1
 kind: Function
 metadata:
   name: function-cue


### PR DESCRIPTION
### Description

This PR updates Function package manifests to use `v1` instead of `v1beta1` for:

- `meta.pkg.crossplane.io`
- `pkg.crossplane.io`

Both `Function` and `FunctionRevision` already use `v1` as their storage version, so this change does not affect existing Crossplane installations when  Crossplane >= 1.17.x

The change only impacts newly built function packages, which will now be published using `v1`. Installing or upgrading these packages in an existing control plane works without disruption.

Related issue: https://github.com/crossplane/crossplane/issues/6947